### PR TITLE
Sun

### DIFF
--- a/document-stream.html
+++ b/document-stream.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document Stream</title>
+    <style>
+        ul {
+            text-align: center;
+            /* 方法三 */
+            display: flex;
+            justify-content: center;
+        }
+
+        li {
+            display: inline-block;
+            background: #000;
+            /* 方法一： 紧密连接节点 */
+            /* margin-left: -5px; // 方法二 */
+            
+        }
+    </style>
+</head>
+
+<body>
+    <ul>
+        <li>1</li>
+        <li>2</li>
+        <li>3</li>
+    </ul>
+</body>
+
+</html>

--- a/document-stream.html
+++ b/document-stream.html
@@ -10,8 +10,8 @@
         ul {
             text-align: center;
             /* 方法三 */
-            display: flex;
-            justify-content: center;
+            /* display: flex;
+            justify-content: center; */
         }
 
         li {
@@ -19,7 +19,6 @@
             background: #000;
             /* 方法一： 紧密连接节点 */
             /* margin-left: -5px; // 方法二 */
-            
         }
     </style>
 </head>


### PR DESCRIPTION
空白折叠：换行编写行内元素，排版会出现5px空隙，三种方案：排版时不要换行；弥补排版时的5px空隙；更换排版方式